### PR TITLE
blog cards

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -8,6 +8,10 @@ import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { BlogCardProps } from "./types/Card";
 export { BlogCardProps } from "./types/Card";
 export namespace Components {
+    interface BasicCta {
+        "buttonText": string;
+        "headingText": string;
+    }
     interface BlogCard {
         "cardCategory": BlogCardProps['cardCategory'];
         "cardFooterText": BlogCardProps['cardFooterText'];
@@ -33,6 +37,12 @@ export namespace Components {
     }
 }
 declare global {
+    interface HTMLBasicCtaElement extends Components.BasicCta, HTMLStencilElement {
+    }
+    var HTMLBasicCtaElement: {
+        prototype: HTMLBasicCtaElement;
+        new (): HTMLBasicCtaElement;
+    };
     interface HTMLBlogCardElement extends Components.BlogCard, HTMLStencilElement {
     }
     var HTMLBlogCardElement: {
@@ -64,6 +74,7 @@ declare global {
         new (): HTMLCtaSliderElement;
     };
     interface HTMLElementTagNameMap {
+        "basic-cta": HTMLBasicCtaElement;
         "blog-card": HTMLBlogCardElement;
         "blog-card-wide": HTMLBlogCardWideElement;
         "blog-cards": HTMLBlogCardsElement;
@@ -72,6 +83,10 @@ declare global {
     }
 }
 declare namespace LocalJSX {
+    interface BasicCta {
+        "buttonText"?: string;
+        "headingText"?: string;
+    }
     interface BlogCard {
         "cardCategory"?: BlogCardProps['cardCategory'];
         "cardFooterText"?: BlogCardProps['cardFooterText'];
@@ -96,6 +111,7 @@ declare namespace LocalJSX {
         "text"?: string;
     }
     interface IntrinsicElements {
+        "basic-cta": BasicCta;
         "blog-card": BlogCard;
         "blog-card-wide": BlogCardWide;
         "blog-cards": BlogCards;
@@ -107,6 +123,7 @@ export { LocalJSX as JSX };
 declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
+            "basic-cta": LocalJSX.BasicCta & JSXBase.HTMLAttributes<HTMLBasicCtaElement>;
             "blog-card": LocalJSX.BlogCard & JSXBase.HTMLAttributes<HTMLBlogCardElement>;
             "blog-card-wide": LocalJSX.BlogCardWide & JSXBase.HTMLAttributes<HTMLBlogCardWideElement>;
             "blog-cards": LocalJSX.BlogCards & JSXBase.HTMLAttributes<HTMLBlogCardsElement>;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -5,17 +5,31 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { BlogCardProps } from "./components/blog-card/blog-card";
-export { BlogCardProps } from "./components/blog-card/blog-card";
+import { BlogCardProps } from "./types/Card";
+export { BlogCardProps } from "./types/Card";
 export namespace Components {
     interface BlogCard {
         "cardCategory": BlogCardProps['cardCategory'];
+        "cardFooterText": BlogCardProps['cardFooterText'];
+        "cardImage": BlogCardProps['cardImage'];
+        "cardLink": BlogCardProps['cardLink'];
+        "cardSummary": BlogCardProps['cardSummary'];
+        "cardTitle": BlogCardProps['cardTitle'];
+    }
+    interface BlogCardWide {
+        "cardFooterText": BlogCardProps['cardFooterText'];
         "cardImage": BlogCardProps['cardImage'];
         "cardLink": BlogCardProps['cardLink'];
         "cardSummary": BlogCardProps['cardSummary'];
         "cardTitle": BlogCardProps['cardTitle'];
     }
     interface BlogCards {
+    }
+    interface BlogCardsWide {
+    }
+    interface CtaSlider {
+        "heading": string;
+        "text": string;
     }
 }
 declare global {
@@ -25,20 +39,49 @@ declare global {
         prototype: HTMLBlogCardElement;
         new (): HTMLBlogCardElement;
     };
+    interface HTMLBlogCardWideElement extends Components.BlogCardWide, HTMLStencilElement {
+    }
+    var HTMLBlogCardWideElement: {
+        prototype: HTMLBlogCardWideElement;
+        new (): HTMLBlogCardWideElement;
+    };
     interface HTMLBlogCardsElement extends Components.BlogCards, HTMLStencilElement {
     }
     var HTMLBlogCardsElement: {
         prototype: HTMLBlogCardsElement;
         new (): HTMLBlogCardsElement;
     };
+    interface HTMLBlogCardsWideElement extends Components.BlogCardsWide, HTMLStencilElement {
+    }
+    var HTMLBlogCardsWideElement: {
+        prototype: HTMLBlogCardsWideElement;
+        new (): HTMLBlogCardsWideElement;
+    };
+    interface HTMLCtaSliderElement extends Components.CtaSlider, HTMLStencilElement {
+    }
+    var HTMLCtaSliderElement: {
+        prototype: HTMLCtaSliderElement;
+        new (): HTMLCtaSliderElement;
+    };
     interface HTMLElementTagNameMap {
         "blog-card": HTMLBlogCardElement;
+        "blog-card-wide": HTMLBlogCardWideElement;
         "blog-cards": HTMLBlogCardsElement;
+        "blog-cards-wide": HTMLBlogCardsWideElement;
+        "cta-slider": HTMLCtaSliderElement;
     }
 }
 declare namespace LocalJSX {
     interface BlogCard {
         "cardCategory"?: BlogCardProps['cardCategory'];
+        "cardFooterText"?: BlogCardProps['cardFooterText'];
+        "cardImage"?: BlogCardProps['cardImage'];
+        "cardLink"?: BlogCardProps['cardLink'];
+        "cardSummary"?: BlogCardProps['cardSummary'];
+        "cardTitle"?: BlogCardProps['cardTitle'];
+    }
+    interface BlogCardWide {
+        "cardFooterText"?: BlogCardProps['cardFooterText'];
         "cardImage"?: BlogCardProps['cardImage'];
         "cardLink"?: BlogCardProps['cardLink'];
         "cardSummary"?: BlogCardProps['cardSummary'];
@@ -46,9 +89,18 @@ declare namespace LocalJSX {
     }
     interface BlogCards {
     }
+    interface BlogCardsWide {
+    }
+    interface CtaSlider {
+        "heading"?: string;
+        "text"?: string;
+    }
     interface IntrinsicElements {
         "blog-card": BlogCard;
+        "blog-card-wide": BlogCardWide;
         "blog-cards": BlogCards;
+        "blog-cards-wide": BlogCardsWide;
+        "cta-slider": CtaSlider;
     }
 }
 export { LocalJSX as JSX };
@@ -56,7 +108,10 @@ declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
             "blog-card": LocalJSX.BlogCard & JSXBase.HTMLAttributes<HTMLBlogCardElement>;
+            "blog-card-wide": LocalJSX.BlogCardWide & JSXBase.HTMLAttributes<HTMLBlogCardWideElement>;
             "blog-cards": LocalJSX.BlogCards & JSXBase.HTMLAttributes<HTMLBlogCardsElement>;
+            "blog-cards-wide": LocalJSX.BlogCardsWide & JSXBase.HTMLAttributes<HTMLBlogCardsWideElement>;
+            "cta-slider": LocalJSX.CtaSlider & JSXBase.HTMLAttributes<HTMLCtaSliderElement>;
         }
     }
 }

--- a/src/components/basic-cta/basic-cta.tsx
+++ b/src/components/basic-cta/basic-cta.tsx
@@ -1,0 +1,22 @@
+import { Component, Prop, Host, h } from '@stencil/core';
+
+@Component({
+  tag: 'basic-cta',
+})
+export class BasicCta {
+  @Prop() headingText: string;
+  @Prop() buttonText: string;
+
+  render() {
+    return (
+      <Host class="text-gray-600 body-font">
+        <div class="container px-5 py-24 mx-auto">
+          <div class="lg:w-2/3 flex flex-col sm:flex-row sm:items-center items-start mx-auto">
+            <h1 class="flex-grow sm:pr-16 text-2xl font-medium title-font text-gray-900">{this.headingText}</h1>
+            <button class="flex-shrink-0 text-white bg-pink-500 border-0 py-2 px-8 focus:outline-none hover:bg-indigo-600 rounded text-lg mt-10 sm:mt-0">{this.buttonText}</button>
+          </div>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/src/components/basic-cta/test/basic-cta.e2e.ts
+++ b/src/components/basic-cta/test/basic-cta.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('basic-cta', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<basic-cta></basic-cta>');
+
+    const element = await page.find('basic-cta');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/src/components/basic-cta/test/basic-cta.spec.tsx
+++ b/src/components/basic-cta/test/basic-cta.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { BasicCta } from '../basic-cta';
+
+describe('basic-cta', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [BasicCta],
+      html: `<basic-cta></basic-cta>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <basic-cta>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </basic-cta>
+    `);
+  });
+});

--- a/src/components/blog-card-wide/blog-card-wide.tsx
+++ b/src/components/blog-card-wide/blog-card-wide.tsx
@@ -1,0 +1,36 @@
+import { Component, Host, Prop, h } from '@stencil/core';
+import { BlogCardProps } from '../../types/Card';
+
+@Component({
+  tag: 'blog-card-wide',
+})
+export class BlogCardWide {
+  @Prop() cardTitle: BlogCardProps['cardTitle'];
+  @Prop() cardSummary: BlogCardProps['cardSummary'];
+  @Prop() cardImage: BlogCardProps['cardImage'];
+  @Prop() cardFooterText: BlogCardProps['cardFooterText'];
+  @Prop() cardLink: BlogCardProps['cardLink'];
+
+  render() {
+    return (
+      <Host class="p-4 md:w-1/3 sm:mb-0 mb-6">
+        {this.cardImage && (
+          <div class="rounded-lg h-64 overflow-hidden">
+            <img alt="content" class="object-cover object-center h-full w-full" src={this.cardImage} />
+          </div>
+        )}
+
+        {this.cardTitle && <h2 class="text-xl font-medium title-font text-gray-900 mt-5">{this.cardTitle}</h2>}
+
+        {this.cardSummary && <p class="text-base leading-relaxed mt-2">{this.cardSummary}</p>}
+
+        <a class="text-pink-500 inline-flex items-center mt-3" href={this.cardLink}>
+          {this.cardFooterText || 'Learn More'}
+          <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" className="w-4 h-4 ml-2" viewBox="0 0 24 24">
+            <path d="M5 12h14M12 5l7 7-7 7"></path>
+          </svg>
+        </a>
+      </Host>
+    );
+  }
+}

--- a/src/components/blog-card-wide/readme.md
+++ b/src/components/blog-card-wide/readme.md
@@ -1,4 +1,4 @@
-# blog-card
+# blog-card-wide
 
 
 
@@ -9,7 +9,6 @@
 
 | Property         | Attribute          | Description | Type     | Default     |
 | ---------------- | ------------------ | ----------- | -------- | ----------- |
-| `cardCategory`   | `card-category`    |             | `string` | `undefined` |
 | `cardFooterText` | `card-footer-text` |             | `string` | `undefined` |
 | `cardImage`      | `card-image`       |             | `string` | `undefined` |
 | `cardLink`       | `card-link`        |             | `string` | `undefined` |

--- a/src/components/blog-card-wide/test/blog-card-wide.e2e.ts
+++ b/src/components/blog-card-wide/test/blog-card-wide.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('blog-card-wide', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<blog-card-wide></blog-card-wide>');
+
+    const element = await page.find('blog-card-wide');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/src/components/blog-card-wide/test/blog-card-wide.spec.tsx
+++ b/src/components/blog-card-wide/test/blog-card-wide.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { BlogCardWide } from '../blog-card-wide';
+
+describe('blog-card-wide', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [BlogCardWide],
+      html: `<blog-card-wide></blog-card-wide>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <blog-card-wide>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </blog-card-wide>
+    `);
+  });
+});

--- a/src/components/blog-card/blog-card.tsx
+++ b/src/components/blog-card/blog-card.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, h } from '@stencil/core';
+import { Component, Prop, Host, h } from '@stencil/core';
 
 export type BlogCardProps = {
   cardCategory: string;
@@ -19,9 +19,8 @@ export class BlogCard {
   @Prop() cardLink: BlogCardProps['cardLink'];
 
   render() {
-    console.log(this.cardSummary);
     return (
-      <div class="p-4 md:w-1/3">
+      <Host class="p-4 md:w-1/3">
         <div class="h-full border-2 border-gray-200 border-opacity-60 rounded-lg overflow-hidden">
           {this.cardImage && <img class="lg:h-48 md:h-36 w-full object-cover object-center" src={this.cardImage} alt={this.cardTitle || 'image'} />}
 
@@ -43,7 +42,7 @@ export class BlogCard {
             </div>
           </div>
         </div>
-      </div>
+      </Host>
     );
   }
 }

--- a/src/components/blog-card/blog-card.tsx
+++ b/src/components/blog-card/blog-card.tsx
@@ -1,12 +1,5 @@
 import { Component, Prop, Host, h } from '@stencil/core';
-
-export type BlogCardProps = {
-  cardCategory: string;
-  cardImage: string;
-  cardSummary: string;
-  cardTitle: string;
-  cardLink: string;
-};
+import { BlogCardProps } from '../../types/Card';
 
 @Component({
   tag: 'blog-card',
@@ -17,6 +10,7 @@ export class BlogCard {
   @Prop() cardSummary: BlogCardProps['cardSummary'];
   @Prop() cardTitle: BlogCardProps['cardTitle'];
   @Prop() cardLink: BlogCardProps['cardLink'];
+  @Prop() cardFooterText: BlogCardProps['cardFooterText'];
 
   render() {
     return (
@@ -33,7 +27,7 @@ export class BlogCard {
 
             <div class="flex items-center flex-wrap">
               <a class="text-pink-500 inline-flex items-center md:mb-2 lg:mb-0" href={this.cardLink}>
-                Learn More
+                {this.cardFooterText || 'Learn More'}
                 <svg className="w-4 h-4 ml-2" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
                   <path d="M5 12h14"></path>
                   <path d="M12 5l7 7-7 7"></path>

--- a/src/components/blog-cards-wide/blog-cards-wide.tsx
+++ b/src/components/blog-cards-wide/blog-cards-wide.tsx
@@ -1,0 +1,18 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'blog-cards-wide',
+})
+export class BlogCardsWide {
+  render() {
+    return (
+      <section class="text-gray-600 body-font">
+        <div class="container px-5 py-24 mx-auto">
+          <div class="flex flex-wrap sm:-m-4 -mx-4 -mb-10 -mt-4">
+            <slot />
+          </div>
+        </div>
+      </section>
+    );
+  }
+}

--- a/src/components/blog-cards-wide/readme.md
+++ b/src/components/blog-cards-wide/readme.md
@@ -1,0 +1,10 @@
+# blog-cards-wide
+
+
+
+<!-- Auto Generated Below -->
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/blog-cards-wide/test/blog-cards-wide.e2e.ts
+++ b/src/components/blog-cards-wide/test/blog-cards-wide.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('blog-cards-wide', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<blog-cards-wide></blog-cards-wide>');
+
+    const element = await page.find('blog-cards-wide');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/src/components/blog-cards-wide/test/blog-cards-wide.spec.tsx
+++ b/src/components/blog-cards-wide/test/blog-cards-wide.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { BlogCardsWide } from '../blog-cards-wide';
+
+describe('blog-cards-wide', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [BlogCardsWide],
+      html: `<blog-cards-wide></blog-cards-wide>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <blog-cards-wide>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </blog-cards-wide>
+    `);
+  });
+});

--- a/src/components/blog-cards/blog-cards.tsx
+++ b/src/components/blog-cards/blog-cards.tsx
@@ -1,17 +1,18 @@
-import { Component, Host, h } from '@stencil/core';
+import { Component, h } from '@stencil/core';
 
 @Component({
   tag: 'blog-cards',
-  shadow: true,
 })
 export class BlogCards {
-
   render() {
     return (
-      <Host>
-        <slot></slot>
-      </Host>
+      <section class="text-gray-600 body-font">
+        <div class="container px-5 py-24 mx-auto">
+          <div class="flex flex-wrap -m-4">
+            <slot />
+          </div>
+        </div>
+      </section>
     );
   }
-
 }

--- a/src/components/blog-cards/readme.md
+++ b/src/components/blog-cards/readme.md
@@ -1,0 +1,10 @@
+# blog-cards
+
+
+
+<!-- Auto Generated Below -->
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/cta-slider/cta-slider.tsx
+++ b/src/components/cta-slider/cta-slider.tsx
@@ -1,0 +1,28 @@
+import { Component, Host, Prop, h } from '@stencil/core';
+
+export type CtaSliderProps = {
+  heading: string;
+  text: string;
+};
+
+@Component({
+  tag: 'cta-slider',
+})
+export class CtaSlider {
+  @Prop() heading: string;
+  @Prop() text: string;
+
+  render() {
+    return (
+      <Host class="flex flex-col">
+        <div class="h-1 bg-gray-200 rounded overflow-hidden">
+          <div class="w-24 h-full bg-pink-500"></div>
+        </div>
+        <div class="flex flex-wrap sm:flex-row flex-col py-6 mb-12">
+          <h1 class="sm:w-2/5 text-gray-900 font-medium title-font text-2xl mb-2 sm:mb-0">{this.heading}</h1>
+          <p class="sm:w-3/5 leading-relaxed text-base sm:pl-10 pl-0">{this.text}</p>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/src/components/cta-slider/readme.md
+++ b/src/components/cta-slider/readme.md
@@ -1,0 +1,18 @@
+# cta-slider
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property  | Attribute | Description | Type     | Default     |
+| --------- | --------- | ----------- | -------- | ----------- |
+| `heading` | `heading` |             | `string` | `undefined` |
+| `text`    | `text`    |             | `string` | `undefined` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/cta-slider/test/cta-slider.e2e.ts
+++ b/src/components/cta-slider/test/cta-slider.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('cta-slider', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<cta-slider></cta-slider>');
+
+    const element = await page.find('cta-slider');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/src/components/cta-slider/test/cta-slider.spec.tsx
+++ b/src/components/cta-slider/test/cta-slider.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { CtaSlider } from '../cta-slider';
+
+describe('cta-slider', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [CtaSlider],
+      html: `<cta-slider></cta-slider>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <cta-slider>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </cta-slider>
+    `);
+  });
+});

--- a/src/index.html
+++ b/src/index.html
@@ -38,5 +38,14 @@
         <blog-card card-title="Test 1" card-summary="This is the summary area for things" card-category="General"></blog-card>
       </blog-cards>
     </section>
+
+    <section>
+      <h3>Blog Cards - Wide</h3>
+      <blog-cards-wide>
+        <blog-card-wide card-title="Test 1" card-summary="This is the summary area for things"></blog-card-wide>
+        <blog-card-wide card-title="Test 1" card-summary="This is the summary area for things"></blog-card-wide>
+        <blog-card-wide card-title="Test 1" card-summary="This is the summary area for things"></blog-card-wide>
+      </blog-cards-wide>
+    </section>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -4,12 +4,39 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>BuddhaBeard UI</title>
-
     <link rel="stylesheet" href="/build/buddhabeard.css" />
     <script type="module" src="/build/buddhabeard.esm.js"></script>
     <script nomodule src="/build/buddhabeard.js"></script>
+    <style>
+      section {
+        display: flex;
+        flex-wrap: wrap;
+        min-width: 300px;
+        margin: 0 auto 30px;
+        justify-content: center;
+      }
+
+      h3 {
+        font-size: 36px;
+        margin: 0;
+        width: 100%;
+        text-align: center;
+      }
+    </style>
   </head>
   <body>
-    <blog-card card-title="Test 1" card-summary="This is the summary area for things" card-category="General"></blog-card>
+    <section>
+      <h3>Blog Card</h3>
+      <blog-card card-title="Test 1" card-summary="This is the summary area for things" card-category="General" card-link="https://buddhabeard.com"></blog-card>
+    </section>
+
+    <section>
+      <h3>Blog Cards</h3>
+      <blog-cards>
+        <blog-card card-title="Test 1" card-summary="This is the summary area for things" card-category="General"></blog-card>
+        <blog-card card-title="Test 1" card-summary="This is the summary area for things" card-category="General"></blog-card>
+        <blog-card card-title="Test 1" card-summary="This is the summary area for things" card-category="General"></blog-card>
+      </blog-cards>
+    </section>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -30,22 +30,21 @@
       <blog-card card-title="Test 1" card-summary="This is the summary area for things" card-category="General" card-link="https://buddhabeard.com"></blog-card>
     </section>
 
-    <section>
-      <h3>Blog Cards</h3>
-      <blog-cards>
-        <blog-card card-title="Test 1" card-summary="This is the summary area for things" card-category="General"></blog-card>
-        <blog-card card-title="Test 1" card-summary="This is the summary area for things" card-category="General"></blog-card>
-        <blog-card card-title="Test 1" card-summary="This is the summary area for things" card-category="General"></blog-card>
-      </blog-cards>
-    </section>
+    <h3>Blog Cards</h3>
+    <blog-cards>
+      <blog-card card-title="Test 1" card-summary="This is the summary area for things" card-category="General"></blog-card>
+      <blog-card card-title="Test 1" card-summary="This is the summary area for things" card-category="General"></blog-card>
+      <blog-card card-title="Test 1" card-summary="This is the summary area for things" card-category="General"></blog-card>
+    </blog-cards>
 
-    <section>
-      <h3>Blog Cards - Wide</h3>
-      <blog-cards-wide>
-        <blog-card-wide card-title="Test 1" card-summary="This is the summary area for things"></blog-card-wide>
-        <blog-card-wide card-title="Test 1" card-summary="This is the summary area for things"></blog-card-wide>
-        <blog-card-wide card-title="Test 1" card-summary="This is the summary area for things"></blog-card-wide>
-      </blog-cards-wide>
-    </section>
+    <h3>Blog Cards - Wide</h3>
+    <blog-cards-wide>
+      <blog-card-wide card-title="Test 1" card-summary="This is the summary area for things"></blog-card-wide>
+      <blog-card-wide card-title="Test 1" card-summary="This is the summary area for things"></blog-card-wide>
+      <blog-card-wide card-title="Test 1" card-summary="This is the summary area for things"></blog-card-wide>
+    </blog-cards-wide>
+
+    <h3>Basic CTA</h3>
+    <basic-cta heading-text="This is the main selling point!" button-text="Let's Go!"></basic-cta>
   </body>
 </html>

--- a/src/mocks/blogData.ts
+++ b/src/mocks/blogData.ts
@@ -1,7 +1,7 @@
 import { BlogCardProps } from '../components';
 
 export type BlogData = {
-  cards: BlogCardProps[];
+  cards: Omit<BlogCardProps, 'cardFooterText'>[];
 };
 
 const blogData: BlogData = {

--- a/src/types/Card.ts
+++ b/src/types/Card.ts
@@ -1,0 +1,8 @@
+export type BlogCardProps = {
+  cardCategory: string;
+  cardImage: string;
+  cardSummary: string;
+  cardTitle: string;
+  cardLink: string;
+  cardFooterText: string;
+};


### PR DESCRIPTION
This example screen doesn't show images, but they are still implemented _if_ a `card-image` property is used.

![image](https://github.com/buddhabeard/bb-ui/assets/1900735/fb21c97f-238f-4ba6-8c3a-3f8fe74eb8f4)

![image](https://github.com/buddhabeard/bb-ui/assets/1900735/f821b131-987a-4539-a3b8-4d7465616f5e)

![image](https://github.com/buddhabeard/bb-ui/assets/1900735/55d6baeb-1b63-4c4f-88bb-6d6bc98eaa84)

